### PR TITLE
fix repo name and streamlit run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
 1. Clone the repository:
 
    ```
-   git clone https://github.com/flipflop4/TALLMesh_multi_page.git 
-   cd tallmesh_multi_page
+   git clone https://github.com/sdptn/TALLMesh_multi_page
+   cd TALLMesh_multi_page
    ```
 
 2. Create a virtual environment:
@@ -93,7 +93,7 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
 1. Start the Streamlit app:
 
    ```
-   streamlit run Tallmesh.py
+   streamlit run TALLMesh.py
    ```
 
 2. Follow the on-screen instructions to:
@@ -104,8 +104,6 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
    - Generate visualizations and reports
 
 ## Streamlit Cloud Deployment
-
-### Streamlit Cloud Deployment
 
 For a simpler deployment option without setting up a local environment, you can deploy TALLMesh directly to Streamlit Cloud:
 


### PR DESCRIPTION
Hiya - I was looking at this for a colleague who was having some trouble and noticed the install instructions in the README.md seem to be from when the repo was at flipflop4/TALLMesh_multi_page rather than sdptn/TALLMesh_multi_page. Also the script being called by steamlit was called `Tallmesh.py` rather than `TALLMesh.py` I have fixed these minor issues.

