### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
 1. Clone the repository:
 
    ```
-   git clone https://github.com/flipflop4/TALLMesh_multi_page.git 
-   cd tallmesh_multi_page
+   git clone https://github.com/sdptn/TALLMesh_multi_page
+   cd TALLMesh_multi_page
    ```
 
 2. Create a virtual environment:
@@ -93,7 +93,7 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
 1. Start the Streamlit app:
 
    ```
-   streamlit run Tallmesh.py
+   streamlit run TALLMesh.py
    ```
 
 2. Follow the on-screen instructions to:
@@ -104,8 +104,6 @@ During this stage the LLM is tasked with identifying patterns and grouping assoc
    - Generate visualizations and reports
 
 ## Streamlit Cloud Deployment
-
-### Streamlit Cloud Deployment
 
 For a simpler deployment option without setting up a local environment, you can deploy TALLMesh directly to Streamlit Cloud:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ Pygments==2.18.0
 pyinstaller==6.10.0
 pyinstaller-hooks-contrib==2024.8
 PyJWT==2.8.0
-PyMuPDF==1.24.10
+PyMuPDF==1.25.4
 PyMuPDFb==1.24.10
 pyparsing==3.1.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Hi - I was looking at this for a colleague who was having issues with the 📤 File Upload and Conversion module in the `streamlit` app:

```
ModuleNotFoundError: No module named 'frontend'
Traceback:
File "/home/tallmesh_fork/TALLMesh_multi_page/venv/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
File "/home/tallmesh_fork/TALLMesh_multi_page/venv/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 590, in code_to_exec
    exec(code, module.__dict__)
File "/home/tallmesh_fork/TALLMesh_multi_page/pages/14_📤_File_Upload_and_Conversion.py", line 24, in <module>
    import fitz  # PyMuPDF
File "/home/tallmesh_fork/TALLMesh_multi_page/venv/lib/python3.10/site-packages/fitz/__init__.py", line 1, in <module>
    from frontend import *
```

I was able to fix this by updating `PyMuPDF==1.24.10` to `PyMuPDF==1.25.4`. That's all this PR does.